### PR TITLE
Client pool

### DIFF
--- a/client.go
+++ b/client.go
@@ -34,6 +34,7 @@ func (this *Client) sendJsonRequest(jsonRequest []byte) ([]byte, error) {
 	httpRequest.Header.Set("Content-Type", "application/json")
 	httpRequest.Header.Set("Content-Length", "")
 	httpRequest.Header.Set("Accept", "application/json")
+	httpRequest.Header.Set("Connection", "close")
 
 	httpResponse, err := httpClient.Do(httpRequest)
 	if err != nil {

--- a/pool.go
+++ b/pool.go
@@ -5,12 +5,12 @@ import (
 	"strings"
 )
 
-type JSONRPCPool struct {
+type Pool struct {
 	clients chan (*Client)
 }
 
-func NewJSONRPCPool(url string, n int) *JSONRPCPool {
-	pool := new(JSONRPCPool)
+func NewPool(url string, n int) *Pool {
+	pool := new(Pool)
 	pool.clients = make(chan (*Client), n)
 
 	for i := 0; i < n; i++ {
@@ -21,15 +21,15 @@ func NewJSONRPCPool(url string, n int) *JSONRPCPool {
 	return pool
 }
 
-func (this *JSONRPCPool) getClient() *Client {
+func (this *Pool) getClient() *Client {
 	return <-this.clients
 }
 
-func (this *JSONRPCPool) releaseClient(c *Client) {
+func (this *Pool) releaseClient(c *Client) {
 	this.clients <- c
 }
 
-func (this *JSONRPCPool) Do(command, methodName string, params interface{}, result interface{}) error {
+func (this *Pool) Do(command, methodName string, params interface{}, result interface{}) error {
 	c := this.getClient()
 	defer this.releaseClient(c)
 

--- a/pool.go
+++ b/pool.go
@@ -1,0 +1,51 @@
+package gojsonrpc
+
+import (
+	"errors"
+	"strings"
+)
+
+type JSONRPCPool struct {
+	clients chan (*Client)
+}
+
+func NewJSONRPCPool(url string, n int) *JSONRPCPool {
+	pool := new(JSONRPCPool)
+	pool.clients = make(chan (*Client), n)
+
+	for i := 0; i < n; i++ {
+		newClient := NewClient(url)
+		pool.clients <- newClient
+	}
+
+	return pool
+}
+
+func (this *JSONRPCPool) getClient() *Client {
+	return <-this.clients
+}
+
+func (this *JSONRPCPool) releaseClient(c *Client) {
+	this.clients <- c
+}
+
+func (this *JSONRPCPool) Do(command, methodName string, params interface{}, result interface{}) error {
+	c := this.getClient()
+	defer this.releaseClient(c)
+
+	switch strings.ToLower(command) {
+	case "run":
+		err := c.Run(methodName, params, result)
+		if err != nil {
+			return err
+		}
+		break
+	case "notify":
+		c.Notify(methodName, params)
+		break
+	default:
+		return errors.New("Invalid JSONRPC command")
+	}
+
+	return nil
+}


### PR DESCRIPTION
This branch introduces a GOJSONRPC client pool.

Usage:

```
var JSONRPCConnectionPool *gojsonrpc.Pool

if JSONRPCConnectionPool == nil {
	JSONRPCConnectionPool = gojsonrpc.NewPool(RPCServerUrl, 10)
}

err := JSONRPCConnectionPool.Do("Run", "RPCName.MethodName", params, result)
```