### PR TITLE
HTTP Proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ func main() {
 	client := gojsonrpc.NewClient("http://mock.rpcservice.url")
 	
 	// you can optionally set a HTTP proxy for the connection
-	client.SetHTTPProxy("http://proxy.url:3128")
+	proxyURL, _ := "http://proxy.url:3128"
+	client.SetHTTPProxy(proxyURL)
 	
 	// you can also optionally set the connection timeout
 	client.SetTimeout(120)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# gojsonrpc
+
+This package provides a client to JSON RPC services.
+
+## Usage example
+
+```go
+package main
+
+import (
+	"log"
+	"github.com/qurami/gojsonrpc"
+)
+
+func main() {
+	client := gojsonrpc.NewClient("http://mock.rpcservice.url")
+	
+	// you can optionally set a HTTP proxy for the connection
+	client.SetHTTPProxy("http://proxy.url:3128")
+	
+	// you can also optionally set the connection timeout
+	client.SetTimeout(120)
+
+	args := map[string]interface{}{}
+	names := make([]string, 0)
+
+	err := client.Run("GetNames", args, &names)
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Println(names)
+}
+```

--- a/client.go
+++ b/client.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -14,28 +15,35 @@ import (
 type Client struct {
 	URL     string
 	Timeout int
+
+	proxyAddress string
 }
 
 // NewClient returns a newly istantiated Client pointing to the given url.
 func NewClient(url string) *Client {
-	client := new(Client)
-
-	client.URL = url
-	client.Timeout = defaultTimeout
-
-	return client
+	return &Client{
+		URL:     url,
+		Timeout: defaultTimeout,
+	}
 }
 
 func (c *Client) sendJSONRequest(jsonRequest []byte) ([]byte, error) {
 	var jsonResponse []byte
 
-	httpClient := &http.Client{
-		Timeout: time.Duration(time.Duration(c.Timeout) * time.Second),
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true,
-			},
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
 		},
+		Proxy: http.ProxyFromEnvironment,
+	}
+
+	if proxyURL, err := url.Parse(c.proxyAddress); c.proxyAddress != "" && err == nil {
+		transport.Proxy = http.ProxyURL(proxyURL)
+	}
+
+	httpClient := &http.Client{
+		Timeout:   time.Duration(time.Duration(c.Timeout) * time.Second),
+		Transport: transport,
 	}
 
 	httpRequest, err := http.NewRequest("POST", c.URL, strings.NewReader(string(jsonRequest)))
@@ -62,6 +70,11 @@ func (c *Client) sendJSONRequest(jsonRequest []byte) ([]byte, error) {
 // SetTimeout sets the client timeout to the given value.
 func (c *Client) SetTimeout(timeout int) {
 	c.Timeout = timeout
+}
+
+// SetHTTPProxy tells the client to use the given httpProxyURL as proxy address.
+func (c *Client) SetHTTPProxy(httpProxyURL string) {
+	c.proxyAddress = httpProxyURL
 }
 
 // Run executes the given method having the given params setting the response

--- a/client.go
+++ b/client.go
@@ -13,35 +13,36 @@ import (
 
 // Client executes JSON RPC calls to remote servers.
 type Client struct {
-	URL string
-
-	timeout    int
-	proxyURL   string
+	serverURL  string
 	httpClient *http.Client
 }
 
 // NewClient returns a newly istantiated Client pointing to the given url.
 func NewClient(url string) *Client {
-	client := &Client{
-		URL:      url,
-		timeout:  defaultTimeout,
-		proxyURL: "",
+	httpClient := &http.Client{
+		Timeout: time.Duration(time.Duration(defaultTimeout) * time.Second),
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+			Proxy: http.ProxyFromEnvironment,
+		},
 	}
-	client.setHTTPClient()
 
-	return client
+	return &Client{
+		serverURL:  url,
+		httpClient: httpClient,
+	}
 }
 
 // SetTimeout sets the client timeout to the given value.
 func (c *Client) SetTimeout(timeout int) {
-	c.timeout = timeout
-	c.setHTTPClient()
+	c.httpClient.Timeout = time.Duration(timeout) * time.Second
 }
 
-// SetHTTPProxy tells the client to use the given httpProxyURL as proxy address.
-func (c *Client) SetHTTPProxy(httpProxyURL string) {
-	c.proxyURL = httpProxyURL
-	c.setHTTPClient()
+// SetHTTPProxyURL tells the client to use the given proxyURL as proxy address.
+func (c *Client) SetHTTPProxyURL(proxyURL *url.URL) {
+	c.httpClient.Transport.(*http.Transport).Proxy = http.ProxyURL(proxyURL)
 }
 
 // Run executes the given method having the given params setting the response
@@ -92,30 +93,10 @@ func (c *Client) Notify(method string, params interface{}) error {
 	return nil
 }
 
-func (c *Client) setHTTPClient() {
-	transport := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true,
-		},
-		Proxy: http.ProxyFromEnvironment,
-	}
-
-	if parsedProxyURL, err := url.Parse(c.proxyURL); c.proxyURL != "" && err == nil {
-		transport.Proxy = http.ProxyURL(parsedProxyURL)
-	}
-
-	newHTTPClient := &http.Client{
-		Timeout:   time.Duration(time.Duration(c.timeout) * time.Second),
-		Transport: transport,
-	}
-
-	c.httpClient = newHTTPClient
-}
-
 func (c *Client) sendJSONRequest(jsonRequest []byte) ([]byte, error) {
 	var jsonResponse []byte
 
-	httpRequest, err := http.NewRequest("POST", c.URL, strings.NewReader(string(jsonRequest)))
+	httpRequest, err := http.NewRequest("POST", c.serverURL, strings.NewReader(string(jsonRequest)))
 	httpRequest.Header.Set("Content-Type", "application/json")
 	httpRequest.Header.Set("Content-Length", "")
 	httpRequest.Header.Set("Accept", "application/json")

--- a/client_test.go
+++ b/client_test.go
@@ -1,21 +1,18 @@
 package gojsonrpc
 
 import (
-	"reflect"
 	"testing"
+	"time"
 )
 
 func TestThatNewClientReturnsTheExpectedClient(t *testing.T) {
 	mockURL := "http://mock.url"
 
-	expectedClient := &Client{
-		URL:     mockURL,
-		Timeout: defaultTimeout,
-	}
-
 	sut := NewClient(mockURL)
 
-	if !reflect.DeepEqual(sut, expectedClient) {
+	if sut.timeout != defaultTimeout ||
+		sut.proxyURL != "" ||
+		sut.httpClient.Timeout != time.Duration(defaultTimeout)*time.Second {
 		t.Fatal("expected Client was not received.")
 	}
 }
@@ -24,15 +21,12 @@ func TestThatSetTimeoutSucceeds(t *testing.T) {
 	mockURL := "http://mock.url"
 	mockTimeout := 123
 
-	expectedClient := &Client{
-		URL:     mockURL,
-		Timeout: 123,
-	}
-
 	sut := NewClient(mockURL)
 	sut.SetTimeout(mockTimeout)
 
-	if !reflect.DeepEqual(sut, expectedClient) {
+	if sut.timeout != 123 ||
+		sut.proxyURL != "" ||
+		sut.httpClient.Timeout != time.Duration(123)*time.Second {
 		t.Fatal("expected Client was not received.")
 	}
 }
@@ -41,16 +35,11 @@ func TestThatSetProxySucceeds(t *testing.T) {
 	mockURL := "http://mock.url"
 	mockProxyURL := "http://proxy.url:1234"
 
-	expectedClient := &Client{
-		URL:          mockURL,
-		Timeout:      defaultTimeout,
-		proxyAddress: mockProxyURL,
-	}
-
 	sut := NewClient(mockURL)
 	sut.SetHTTPProxy(mockProxyURL)
 
-	if !reflect.DeepEqual(sut, expectedClient) {
+	if sut.timeout != defaultTimeout ||
+		sut.proxyURL != mockProxyURL {
 		t.Fatal("expected Client was not received.")
 	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,56 @@
+package gojsonrpc
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestThatNewClientReturnsTheExpectedClient(t *testing.T) {
+	mockURL := "http://mock.url"
+
+	expectedClient := &Client{
+		URL:     mockURL,
+		Timeout: defaultTimeout,
+	}
+
+	sut := NewClient(mockURL)
+
+	if !reflect.DeepEqual(sut, expectedClient) {
+		t.Fatal("expected Client was not received.")
+	}
+}
+
+func TestThatSetTimeoutSucceeds(t *testing.T) {
+	mockURL := "http://mock.url"
+	mockTimeout := 123
+
+	expectedClient := &Client{
+		URL:     mockURL,
+		Timeout: 123,
+	}
+
+	sut := NewClient(mockURL)
+	sut.SetTimeout(mockTimeout)
+
+	if !reflect.DeepEqual(sut, expectedClient) {
+		t.Fatal("expected Client was not received.")
+	}
+}
+
+func TestThatSetProxySucceeds(t *testing.T) {
+	mockURL := "http://mock.url"
+	mockProxyURL := "http://proxy.url:1234"
+
+	expectedClient := &Client{
+		URL:          mockURL,
+		Timeout:      defaultTimeout,
+		proxyAddress: mockProxyURL,
+	}
+
+	sut := NewClient(mockURL)
+	sut.SetHTTPProxy(mockProxyURL)
+
+	if !reflect.DeepEqual(sut, expectedClient) {
+		t.Fatal("expected Client was not received.")
+	}
+}

--- a/constants.go
+++ b/constants.go
@@ -1,5 +1,5 @@
 package gojsonrpc
 
 const (
-	DEFAULT_TIMEOUT = 300
+	defaultTimeout = 300
 )


### PR DESCRIPTION
This PR gives users the possibility to connect to remote JSONRPC endpoints using an HTTP Proxy.

In particular:
- The `SetHTTPProxyURL` method has been introduced
- A README w/usage has been created
- (minor) Missing comments were added
- (minor) Missing tests were added