### PR TITLE
chore: propagate http error in response

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Ufirst
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/client.go
+++ b/client.go
@@ -61,21 +61,21 @@ func (c *Client) Run(method string, params interface{}, result interface{}, opts
 		return err
 	}
 
-	jsonResponse, err := c.sendJSONRequest(jsonRequest, opts...)
+	httpResponse, err := c.sendJSONRequest(jsonRequest, opts...)
 	if err != nil {
 		return err
 	}
 
-	response := NewResponse()
-	response.Result = result
+	jsonRPCResponse := NewResponse()
+	jsonRPCResponse.Result = result
 
-	err = json.Unmarshal(jsonResponse, &response)
+	err = json.Unmarshal(httpResponse, &jsonRPCResponse)
 	if err != nil {
 		return err
 	}
 
-	if response.hasError() {
-		return errors.New(response.Error.Message)
+	if jsonRPCResponse.hasError() {
+		return errors.New(jsonRPCResponse.Error.Message)
 	}
 
 	return nil

--- a/client.go
+++ b/client.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -104,8 +105,6 @@ func (c *Client) Notify(method string, params interface{}, opts ...NotifyOptions
 }
 
 func (c *Client) sendJSONRequest(jsonRequest []byte, opts ...RunOptions) ([]byte, error) {
-	var jsonResponse []byte
-
 	httpRequest, err := http.NewRequest("POST", c.serverURL, strings.NewReader(string(jsonRequest)))
 	httpRequest.Header.Set("Content-Type", "application/json")
 	httpRequest.Header.Set("Content-Length", "")
@@ -121,15 +120,19 @@ func (c *Client) sendJSONRequest(jsonRequest []byte, opts ...RunOptions) ([]byte
 
 	httpResponse, err := c.httpClient.Do(httpRequest)
 	if err != nil {
-		return jsonResponse, err
+		return nil, err
 	}
 
 	defer httpResponse.Body.Close()
 
-	jsonResponse, err = ioutil.ReadAll(httpResponse.Body)
+	httpResponseBody, err := ioutil.ReadAll(httpResponse.Body)
 	if err != nil {
-		return jsonResponse, err
+		return httpResponseBody, err
 	}
 
-	return jsonResponse, nil
+	if httpResponse.StatusCode >= http.StatusBadRequest {
+		return nil, fmt.Errorf("received HTTP status %d with body %s", httpResponse.StatusCode, httpResponseBody)
+	}
+
+	return httpResponseBody, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/qurami/gojsonrpc
+
+go 1.15


### PR DESCRIPTION
Issue https://github.com/qurami/roadmap/issues/287

This branch changes the behaviour of the JSON RPC client to propagate any HTTP error over 400 (e.g. Unauthorized).

The HTTP body can be unwrapped from the resulting error.

This PR also includes a minor fix in variable naming across the client.